### PR TITLE
Update Temperature to float32

### DIFF
--- a/request/request.go
+++ b/request/request.go
@@ -23,7 +23,7 @@ type ChatCompletionsRequest struct {
 	Stop             []string        `json:"stop,omitempty"`
 	Stream           bool            `json:"stream,omitempty"`
 	StreamOptions    *StreamOptions  `json:"stream_options,omitempty"`
-	Temperature      int             `json:"temperature,omitempty"`
+	Temperature      *float32        `json:"temperature,omitempty"`
 	TopP             *float32        `json:"top_p,omitempty"`
 	Tools            *[]Tool         `json:"tools,omitempty"`
 	ToolChoice       any             `json:"tool_choice,omitempty"`

--- a/request/request_test/validator_test.go
+++ b/request/request_test/validator_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestValidateChatCompletionsRequest(t *testing.T) {
+	temp := float32(2)
 	req := &request.ChatCompletionsRequest{
 		Messages: []*request.Message{
 			{
@@ -29,7 +30,7 @@ func TestValidateChatCompletionsRequest(t *testing.T) {
 		StreamOptions: &request.StreamOptions{
 			IncludeUsage: true,
 		},
-		Temperature: 2,
+		Temperature: &temp,
 		// TopP: nil,	// TODO: VN -- pass non nil
 	}
 	err := request.ValidateChatCompletionsRequest(req)

--- a/request/validator.go
+++ b/request/validator.go
@@ -110,8 +110,10 @@ func validateMultipleFields(req *ChatCompletionsRequest) error {
 		return fmt.Errorf("err: presence_penalty is invalid; it should be number between -2 and 2")
 	}
 
-	if !(req.Temperature >= 0 && req.Temperature <= 2) {
-		return fmt.Errorf("err: temperature is invalid; it should be number between 0 and 2")
+	if req.Temperature != nil {
+		if !(*req.Temperature >= 0 && *req.Temperature <= 2) {
+			return fmt.Errorf("err: temperature is invalid; it should be number between 0 and 2")
+		}
 	}
 
 	if req.TopP != nil {


### PR DESCRIPTION
Fixes #3

Update the `Temperature` field in `ChatCompletionsRequest` struct to be of type `*float32`.

* **request/request.go**
  - Change `Temperature` field type from `int` to `*float32`.

* **request/validator.go**
  - Modify `validateMultipleFields` function to validate `Temperature` as a `*float32`.

* **request/request_test/validator_test.go**
  - Update `TestValidateChatCompletionsRequest` test to use a `*float32` value for `Temperature`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/go-deepseek/deepseek/pull/4?shareId=f93c7a92-df3d-4e33-a478-1d551945c1ed).